### PR TITLE
show notifications for start, stop and delete actions from the tray menu

### DIFF
--- a/commander.js
+++ b/commander.js
@@ -46,8 +46,14 @@ module.exports = class DaemonCommander {
          method: 'GET'
       };
 
-      const {body} = await got(options);
-      return JSON.parse(body);
+      try {
+         const response = await got(options);
+         return JSON.parse(response.body);
+      } catch (response) {
+         return {
+            error: response.body
+         }
+      }
    }
 
    async stop() {
@@ -56,18 +62,26 @@ module.exports = class DaemonCommander {
          method: 'GET'
       };
 
-      const {body} = await got(options);
-      return JSON.parse(body);
+      try {
+         _ = await got(options);
+         return true;
+      } catch (response) {
+         return { error: response.body };
+      }
    }
 
    async delete() {
       const options = {
          url: this.apiPath + `/delete`,
-         method: 'GET'
+         method: 'DELETE'
       };
-
-      const {body} = await got(options);
-      return JSON.parse(body);
+      
+      try {
+         _ = await got(options);
+         return true;
+      } catch (response) {
+         return { error: response.body };
+      }
    }
 
    async configGet() {

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ function crcBinary() {
 
 let parentWindow = undefined
 var isMac = (os.platform() === "darwin")
+var isWindows = (os.platform() === "win32")
 
 const start = async function() {
   // launching the daemon
@@ -233,4 +234,8 @@ app.whenReady().then(() => {
 
 if (isMac) {
   app.dock.hide()
+}
+
+if (isWindows) {
+  app.setAppUserModelId('com.redhat.crc')
 }

--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-const {app, clipboard, Menu, Tray, BrowserWindow, shell} = require('electron');
+const {app, clipboard, Menu, Tray, BrowserWindow, shell, Notification} = require('electron');
 const path = require('path');
 const childProcess = require('child_process');
 const { dialog } = require('electron')
@@ -138,15 +138,15 @@ createTrayMenu = function(state) {
     { type: 'separator' },
     {
       label: 'Start',
-      click() { commander.start(); }
+      click() { handleStartClick(); }
     },
     {
       label: 'Stop',
-      click() { commander.stop(); }
+      click() { handleStopClick(); }
     },
     {
       label: 'Delete',
-      click() { commander.delete(); }
+      click() { handleDeleteClick(); }
     },
     { type: 'separator' },
     {
@@ -184,6 +184,37 @@ createTrayMenu = function(state) {
   ]);
 
   tray.setContextMenu(contextMenu);
+}
+
+const showNotification = function(title, body) {
+  new Notification({ title: title, body: body }).show()
+}
+
+const handleStartClick = async function() {
+    const startResult = await commander.start();
+    if (startResult.KubeletStarted) {
+      showNotification("Cluster started", "CodeReady Containers cluster successfully started");
+    } else {
+      showNotification("Failed to start cluster", startResult.error);
+    }
+}
+
+const handleDeleteClick = async function() {
+  const deleteResult = await commander.delete();
+  if (deleteResult.deleted) {
+    showNotification("Cluster Deleted", "CodeReady Containers cluster successfully deleted");
+  } else {
+    showNotification("Cluster not deleted", deleteResult.error);
+  }
+}
+
+const handleStopClick = async function() {
+  const stopResult = await commander.stop();
+  if (stopResult.stopped) {
+    showNotification("Cluster Stopped", "CodeReady Containers cluster stopped")
+  } else {
+    showNotification("Cluster did not Stop", stopResult.error);
+  }
 }
 
 app.whenReady().then(() => {

--- a/settings.js
+++ b/settings.js
@@ -23,6 +23,7 @@ const start = async function() {
 
   document.querySelector('#apply').onclick = async() => {
     applyValues();
+    new Notification("Settings Applied", { body: "" }).show();
   }
 
   document.querySelector('#refresh').onclick = async() => {


### PR DESCRIPTION
since we'll be removing the `Error` and `Success` structs, `/stop`, `/delete` would not return a body on success, so we need to make changes in the commander to get this result.