### PR TITLE
Some arguments to simplify debugging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Update NPM
-          command: "sudo npm install -g npm"
-      - run:
           name: Install Wine64 (Needed for windows build)
           command: | 
             sudo apt-get update

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
         "windows": {
           "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
         },
-        "args" : ["."],
+        "args" : [".", "--inspect=5858", "--remote-debugging-port=8315"],
         "outputCapture": "std"
       }
     ]


### PR DESCRIPTION
  * node-inspector on `5858`  
    You can use `chrome://inspect` to debug from the browser
  * devtools on `8315`  
    You can use `http://localhost:8315` to debug from the browser

