### PR TITLE
Add notifications for start, stop and delete actions

### DIFF
--- a/frontend/src/components/SetupWindow.jsx
+++ b/frontend/src/components/SetupWindow.jsx
@@ -292,7 +292,7 @@ const ProvidePullSecret = (props) => {
                         <HelperText>
                             <HelperTextItem icon={<InfoIcon />}>The pull secret is necessary to allow you to pull container images from the registry.
                             A personal pull secret can be obtained from the <a target="_blank"
-                            href="https://cloud.redhat.com/openshift/create/local">CRC download page</a>.
+                            rel="noreferrer" href="https://cloud.redhat.com/openshift/create/local">CRC download page</a>.
                             Please use the "Copy pull secret" option and paste the content into the field above.</HelperTextItem>
                         </HelperText>
                     </HintTitle>

--- a/notification.js
+++ b/notification.js
@@ -1,0 +1,14 @@
+const { Notification } = require('electron');
+
+function showNotification(options) {
+    const n = new Notification({
+        title: "CodeReady Containers",
+        body: options.body
+    })
+    if (options.onClick) {
+        n.on('click',  options.onClick)
+    }
+    n.show()
+}
+
+module.exports = showNotification

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:react": "cd frontend && npm run build",
     "start": "npm run build:react && electron .",
     "release": "npm run build:react && electron-packager . --overwrite --out=release",
-    "release:cross": "npm run build:react && electron-packager . --overwrite --out=release --platform=darwin,linux,win32",
+    "release:cross": "npm run build:react && electron-packager . --overwrite --out=release --platform=darwin,win32",
     "start:dev": "concurrently \"electron .\" \"cd frontend && npm start\""
   },
   "author": "",


### PR DESCRIPTION
- shows a notification when the tray first starts after the setup from on-boarding window is done