### PR TITLE
open links in new window and ask for confirmation before closing on-boarding wizard

### DIFF
--- a/frontend/src/components/SetupWindow.jsx
+++ b/frontend/src/components/SetupWindow.jsx
@@ -72,6 +72,10 @@ class SetupSpinner extends React.Component {
         window.api.closeSetupWizard();
     }
 
+    handleDocsLinks(url) {
+        window.api.openLinkInDefaultBrowser(url)
+    }
+
     render () {
         return (
             <EmptyState>
@@ -82,8 +86,8 @@ class SetupSpinner extends React.Component {
                     <Button isDisabled={this.state.notReadyForUse} variant={ButtonVariant.primary} onClick={this.handlePrimaryButtonAction}>Start using CRC</Button>
                 </EmptyStatePrimary>
                 <EmptyStateSecondaryActions>
-                    <Button variant={ButtonVariant.link} component="a" href="https://crc.dev">Visit Getting started Guide</Button>
-                    <Button variant={ButtonVariant.link} component="a" href="https://crc.dev">Example Deployments</Button>
+                    <Button variant={ButtonVariant.link} onClick={ () => { this.handleDocsLinks("https://crc.dev") }}>Visit Getting started Guide</Button>
+                    <Button variant={ButtonVariant.link} onClick={ () => { this.handleDocsLinks("https://crc.dev") }}>Example Deployments</Button>
                 </EmptyStateSecondaryActions>
             </EmptyState>
         );

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const {
   BrowserWindow,
   shell,
   ipcMain,
-  session 
+  session
 } = require('electron');
 const path = require('path');
 const childProcess = require('child_process');
@@ -96,6 +96,23 @@ function showOnboarding() {
     }
   })
   mainWindow.setMenuBarVisibility(false)
+
+  mainWindow.on('close', async e => {
+    e.preventDefault()
+    const choice = dialog.showMessageBoxSync(mainWindow, {
+      message: "Are you sure you want to close the on-boarding wizard?",
+      title: "CodeReady Containers",
+      type: "warning",
+      buttons: ["Yes", "No"],
+      defaultId: 1,
+      cancelId: 1,
+    })
+
+    if (choice == 0) {
+      mainWindow.destroy()
+      app.quit()
+    }
+  })
 
   let frontEndUrl = getFrontEndUrl();
   mainWindow.loadURL(frontEndUrl)

--- a/main.js
+++ b/main.js
@@ -389,6 +389,10 @@ ipcMain.on('start-tray', (event, arg) => {
   appStart()
 })
 
+ipcMain.on('open-link', (event, arg) => {
+  shell.openExternal(arg)
+})
+
 
 /* ----------------------------------------------------------------------------
 // Setup

--- a/main.js
+++ b/main.js
@@ -76,9 +76,8 @@ function getFrontEndUrl(route) {
 
 function needOnboarding() {
   try {
-    const cp = childProcess.execFileSync(crcBinary(), ["daemon", "--watchdog"],
+    const cp = childProcess.execFileSync(crcBinary(), ["setup", "--check-only"],
                   { windowsHide: true });
-    cp.kill()
     return false
   } catch (e) {
     return true

--- a/preload-main.js
+++ b/preload-main.js
@@ -57,7 +57,7 @@ contextBridge.exposeInMainWorld('api', {
 
   onLogsRetrieved: (cb) => {
     ipcRenderer.on('logs-retrieved', cb);
-  }, 
+  },
 
   telemetry: {
     trackError: (errorMsg) => {

--- a/preload-setup.js
+++ b/preload-setup.js
@@ -1,6 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
+  openLinkInDefaultBrowser: (url) => {
+    ipcRenderer.send('open-link', url)
+  },
+  
   closeActiveWindow: () => { 
       ipcRenderer.send('close-active-window');
   },


### PR DESCRIPTION
- show the on-boarding wizard when necessary (bundle is not available)
- make the links in the setup wizard open in a new window
- ask for confirmation before closing the on-boarding wizard