### PR TITLE
use electron ipc to send telemetry from the renderer processes

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const showNotification = require('./notification');
 
 const config = new Config()
 // create the telemetry object
-const telemetry = new Telemetry(config.get('enableTelemetry'))
+const telemetry = new Telemetry(config.get('enableTelemetry'), getSegmentWriteKey())
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms))
 
@@ -51,6 +51,13 @@ function crcBinary() {
 
   // No path provided
   return "crc"
+}
+
+function getSegmentWriteKey() {
+  if (app.isPackaged) {
+    return 'cvpHsNcmGCJqVzf6YxrSnVlwFSAZaYtp'
+  }
+  return 'R7jGNYYO5gH0Nl5gDlMEuZ3gPlDJKQak'
 }
 
 /* ----------------------------------------------------------------------------
@@ -628,3 +635,15 @@ ipcMain.on('logs-retrieve', async (event, args) => {
     await delay(3000);
   }
 });
+
+/* ----------------------------------------------------------------------------
+// Telemetry
+// ------------------------------------------------------------------------- */
+
+ipcMain.on('track-error', async (event, arg) => {
+  telemetry.trackError(arg)
+})
+
+ipcMain.on('track-success', async (event, arg) => {
+  telemetry.trackSuccess(arg)
+})

--- a/preload-main.js
+++ b/preload-main.js
@@ -1,10 +1,4 @@
 const { contextBridge, ipcRenderer } = require('electron');
-const Config = require('./config');
-const Telemetry = require('./telemetry');
-
-
-const config = new Config()
-const telemetry = new Telemetry(config.get('enableTelemetry'))
 
 contextBridge.exposeInMainWorld('api', {
   closeActiveWindow: () => { 
@@ -61,11 +55,11 @@ contextBridge.exposeInMainWorld('api', {
 
   telemetry: {
     trackError: (errorMsg) => {
-      telemetry.trackError(errorMsg);
+      ipcRenderer.send('track-error', errorMsg);
     },
 
     trackSuccess: (successMsg) => {
-      telemetry.trackSuccess(successMsg);
+     ipcRenderer.send('track-success', successMsg);
     }
   }
 });

--- a/telemetry.js
+++ b/telemetry.js
@@ -6,7 +6,6 @@ const fs = require('fs');
 const {v4: uuidv4 } = require('uuid');
 const hash = require('object-hash');
 
-let writeKey = 'R7jGNYYO5gH0Nl5gDlMEuZ3gPlDJKQak'; // test
 let userIdHashPath = path.join(os.homedir(), '.crc', "segmentIdentityHash");
 let userIdPath = path.join(os.homedir(), '.redhat', 'anonymousId');
 
@@ -25,7 +24,7 @@ module.exports = class Telemetry {
         ip: "0.0.0.0"
     }
 
-    constructor(telemetryEnabled) {
+    constructor(telemetryEnabled, writeKey) {
         this.telemetryEnabled = telemetryEnabled
         
         if (!telemetryEnabled) {

--- a/telemetry.js
+++ b/telemetry.js
@@ -7,7 +7,7 @@ const {v4: uuidv4 } = require('uuid');
 const hash = require('object-hash');
 
 let writeKey = 'R7jGNYYO5gH0Nl5gDlMEuZ3gPlDJKQak'; // test
-let userIdHashPath = path.join(__dirname, "segmentIdentityHash");
+let userIdHashPath = path.join(os.homedir(), '.crc', "segmentIdentityHash");
 let userIdPath = path.join(os.homedir(), '.redhat', 'anonymousId');
 
 if (app.isPackaged) {


### PR DESCRIPTION
this fixes an already existing bug in `preload-main.js` that was detected in 10c5afa