### PR TITLE
Fixes #115 Redesign of ConfigurationWindow: use component with tabs

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": ".",
   "dependencies": {
-    "@code-ready/crc-react-components": "https://github.com/code-ready/crc-react-components/releases/download/0.9.7/crc-react-components-0.9.7.tgz",
+    "@code-ready/crc-react-components": "https://github.com/code-ready/crc-react-components/releases/download/0.9.8/crc-react-components-0.9.8.tgz",
     "@patternfly/react-core": "^4.175.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/frontend/src/components/ConfigurationWindow.jsx
+++ b/frontend/src/components/ConfigurationWindow.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
 import {
-    Bullseye
-} from '@patternfly/react-core';
-import {
     Configuration
 } from '@code-ready/crc-react-components';
 import '@code-ready/crc-react-components/dist/index.css';
@@ -55,15 +52,12 @@ export default class ConfigurationWindow extends React.Component {
 
     render() {
         return (
-            <Bullseye>
-                <div style={{margin: "20px"}}>
-                    <Configuration ref={this.config}
-                        onValueChanged={this.configurationValueChanged}
-                        onSaveClicked={this.configurationSave}
-                        onResetClicked={this.configurationReset}
-                        onPullsecretChangeClicked={this.openPullsecretChangeWindow} />
-                </div>
-            </Bullseye>
+            <Configuration ref={this.config}
+                onValueChanged={this.configurationValueChanged}
+                onSaveClicked={this.configurationSave}
+                onResetClicked={this.configurationReset}
+                onPullsecretChangeClicked={this.openPullsecretChangeWindow}
+                height="320px" />
         );
     }
 }

--- a/main.js
+++ b/main.js
@@ -263,7 +263,7 @@ const appStart = async function() {
 
   // TODO: deal with duplication
   configurationWindow = new BrowserWindow({
-    width: 700,
+    width: 780,
     height: 440,
     resizable: false,
     show: false,


### PR DESCRIPTION
This fixes #71, #115 and most likely #113

![image](https://user-images.githubusercontent.com/1894/151382204-60474cca-8bdb-4a07-9090-6c7e6778b2b3.png)

Note: also, the values are clamped at a reasonable default, never lower than 1 and for memory not below 2G. We do not get the defaults from the backend, so we are limited in setting these boundaries.