### PR TITLE
Add about window

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,8 +14,12 @@
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "@types/node": "^17.0.14",
+    "@types/react": "^17.0.38",
+    "@types/react-dom": "^17.0.11",
     "react-scripts": "4.0.3",
-    "sass": "^1.44.0"
+    "sass": "^1.44.0",
+    "typescript": "^4.5.5"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/about/AboutWindow.module.scss
+++ b/frontend/src/components/about/AboutWindow.module.scss
@@ -1,0 +1,38 @@
+.alignLeft {
+  float: left;
+  font-weight: bold;
+}
+
+.alignRight {
+  float: right;
+  font-weight: bold;
+}
+
+.clearBoth {
+  clear: both;
+}
+
+.marginBox {
+  padding: 20px;
+}
+
+.linksBox{
+  clear: both;
+  margin-top: 50px;
+}
+
+.docButton {
+  padding-left: 0;
+}
+
+.repoButton {
+  padding-right: 0;
+}
+
+.logo {
+  background-image: url("./../../assets/crc-logo-black.png");
+  background-size: cover;
+  background-position: center;
+  width: 450px;
+  height: 200px;
+}

--- a/frontend/src/components/about/AboutWindow.module.scss
+++ b/frontend/src/components/about/AboutWindow.module.scss
@@ -5,7 +5,6 @@
 
 .alignRight {
   float: right;
-  font-weight: bold;
 }
 
 .clearBoth {

--- a/frontend/src/components/about/AboutWindow.tsx
+++ b/frontend/src/components/about/AboutWindow.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Bullseye, Button } from "@patternfly/react-core";
 import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
-import GithubIcon from '@patternfly/react-icons/dist/esm/icons/github-icon';
 import { Versions } from '../../global';
 
 import styles from './AboutWindow.module.scss';
@@ -11,8 +10,7 @@ export class AboutWindow extends React.Component {
   constructor(props: {}) {
     super(props);
     this.state = {}
-    this.openDocumentation = this.openDocumentation.bind(this);
-    this.openRepo = this.openRepo.bind(this);
+    this.openDocumentationLink = this.openDocumentationLink.bind(this);
   }
 
   async componentDidMount(): Promise<void> {
@@ -22,13 +20,10 @@ export class AboutWindow extends React.Component {
     this.setState(versions);
   }
 
-  private openDocumentation(): void {
+  private openDocumentationLink(): void {
     window.api.openLinkInDefaultBrowser(`https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/${this.state.crcVersion}`);
   }
 
-  private openRepo(): void {
-    window.api.openLinkInDefaultBrowser('https://github.com/code-ready/tray-electron');
-  }
 
   render(): React.ReactNode {
 
@@ -51,13 +46,8 @@ export class AboutWindow extends React.Component {
 
           <div className={styles.linksBox}>
             <span className={styles.alignLeft}>
-              <Button variant="link" className={styles.docButton} icon={<ExternalLinkSquareAltIcon />} iconPosition="right" component="a" onClick={this.openDocumentation} target="_blank">
+              <Button variant="link" className={styles.docButton} icon={<ExternalLinkSquareAltIcon />} iconPosition="right" component="a" onClick={this.openDocumentationLink} target="_blank">
                 Documentation
-              </Button>
-            </span>
-            <span className={styles.alignRight}>
-              <Button variant="link" className={styles.repoButton} icon={<GithubIcon />} iconPosition="left" component="a" onClick={this.openRepo} target="_blank">
-                Tray Repository
               </Button>
             </span>
           </div>

--- a/frontend/src/components/about/AboutWindow.tsx
+++ b/frontend/src/components/about/AboutWindow.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Bullseye, Button } from "@patternfly/react-core";
+import ExternalLinkSquareAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-square-alt-icon';
+import GithubIcon from '@patternfly/react-icons/dist/esm/icons/github-icon';
+import { Versions } from '../../global';
+
+import styles from './AboutWindow.module.scss';
+
+export class AboutWindow extends React.Component {
+  state: Versions;
+  constructor(props: {}) {
+    super(props);
+    this.state = {}
+    this.openDocumentation = this.openDocumentation.bind(this);
+    this.openRepo = this.openRepo.bind(this);
+  }
+
+  async componentDidMount(): Promise<void> {
+    // need to set title there, as index.html contains '<title>'
+    window.document.title = "About";
+    const versions = await window.api.about();
+    this.setState(versions);
+  }
+
+  private openDocumentation(): void {
+    window.api.openLinkInDefaultBrowser(`https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/${this.state.crcVersion}`);
+  }
+
+  private openRepo(): void {
+    window.api.openLinkInDefaultBrowser('https://github.com/code-ready/tray-electron');
+  }
+
+  render(): React.ReactNode {
+
+    let bundleVersion: React.ReactNode;
+    if (this.state.ocpBundleVersion) {
+      bundleVersion = <Version title='Red Hat OpenShift Container Platform version' version={this.state.ocpBundleVersion} />
+    } else if (this.state.podmanVersion) {
+      bundleVersion = <Version title='Podman version' version={this.state.podmanVersion} />
+    }
+
+    return (
+      <div className={styles.marginBox}>
+        <Bullseye>
+          <div className={styles.logo} />
+        </Bullseye>
+        <div className={styles.marginBox}>
+          <Version title='Red Hat CodeReady Containers version' version={`${this.state.crcVersion}+${this.state.crcCommit}`} />
+          {bundleVersion}
+          <Version title='Tray version' version={this.state.appVersion} />
+
+          <div className={styles.linksBox}>
+            <span className={styles.alignLeft}>
+              <Button variant="link" className={styles.docButton} icon={<ExternalLinkSquareAltIcon />} iconPosition="right" component="a" onClick={this.openDocumentation} target="_blank">
+                Documentation
+              </Button>
+            </span>
+            <span className={styles.alignRight}>
+              <Button variant="link" className={styles.repoButton} icon={<GithubIcon />} iconPosition="left" component="a" onClick={this.openRepo} target="_blank">
+                Tray Repository
+              </Button>
+            </span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+function Version(props: { title: string; version?: string }): JSX.Element {
+  return <div className={styles.clearBoth}>
+    <span className={styles.alignLeft}>{props.title}</span>
+    <span className={styles.alignRight}>{props.version}</span>
+  </div>;
+}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -1,0 +1,19 @@
+// types for preload-main.js shared contextBridge API
+
+export interface Versions {
+  appVersion?: string;
+  crcVersion?: string;
+  crcCommit?: string;
+  ocpBundleVersion?: string;
+  podmanVersion?: string;
+}
+
+export declare global {
+  interface Window {
+    api: {
+      about: () => Promise<Versions>;
+      openLinkInDefaultBrowser: (url: string) => void;
+      // TODO: add rest of the API
+    }
+  }
+}

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -10,6 +10,7 @@ import LogsWindow from './components/LogsWindow';
 import ConfigurationWindow from './components/ConfigurationWindow';
 import MiniStatusWindow from './components/MiniStatusWindow';
 import PullSecretChangeWindow from './components/PullSecretChangeWindow';
+import { AboutWindow } from './components/about/AboutWindow';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -22,6 +23,7 @@ ReactDOM.render(
         <Route path="/configuration" element={<ConfigurationWindow />} />
         <Route path="/ministatus" element={<MiniStatusWindow />} />
         <Route path="/pullsecret" element={<PullSecretChangeWindow />} />
+        <Route path="/about" element={<AboutWindow />} />
       </Routes>
     </HashRouter>
   </React.StrictMode>,

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/preload-main.js
+++ b/preload-main.js
@@ -1,6 +1,10 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('api', {
+  openLinkInDefaultBrowser: (url) => {
+    ipcRenderer.send('open-link', url)
+  },
+  
   closeActiveWindow: () => { 
     ipcRenderer.send('hide-active-window');
   },
@@ -63,7 +67,11 @@ contextBridge.exposeInMainWorld('api', {
     },
 
     trackSuccess: (successMsg) => {
-     ipcRenderer.send('track-success', successMsg);
+      ipcRenderer.send('track-success', successMsg);
     }
+  },
+
+  about: () => {
+    return ipcRenderer.invoke('get-about');
   }
 });


### PR DESCRIPTION
This PR add new command `About` in trey context menu:
<img width="182" alt="Screenshot 2022-02-03 at 12 29 37" src="https://user-images.githubusercontent.com/929743/152325406-7338abda-b4f9-497c-957c-a3b9becfec9b.png">

The `About` window on mac:

<img width="603" alt="Screenshot 2022-02-07 at 10 38 17" src="https://user-images.githubusercontent.com/929743/152753430-31ece77b-be6f-4151-8153-ea2a2b9ea56b.png">


Also this PR add implemented with TypeScript, it brings `tsconfig.json` and some `*.d.ts` files with types.

Tray version taken from `app.getVersion()`, electron take it from `package.json` of app, so we need to update it during release

Also I  not sure about `bundle` version, for now I use `OpenShiftVersion` value witch return by `/version` daemon call.
