### PR TITLE
Resolve #130 Add dialog API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 package-lock.json
 /release/
 segmentIdentityHash
+/build/
+.DS_Store

--- a/frontend/src/components/dialog/DialogWindow.tsx
+++ b/frontend/src/components/dialog/DialogWindow.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@patternfly/react-core/dist/esm/components/Button';
+import React from 'react';
+import { DialogOptions } from '../../global';
+
+const initialState: DialogOptions = {
+  buttons: [],
+  message: 'No message',
+  title: 'No title',
+};
+export class DialogWindow extends React.Component {
+
+  state: DialogOptions;
+  constructor(props: {}) {
+    super(props);
+    this.state = initialState;
+  }
+
+  async componentDidMount(): Promise<void> {
+    const options = await window.dialogApi.getDialogOptions();
+    this.setState(options);
+    document.title = options.title;
+  }
+
+  private onButtonClick(item: string): void {
+    window.dialogApi.buttonClicked(item);
+  }
+
+  render(): React.ReactNode {
+    let counter = 0;
+    return (
+      <div style={{ margin: "20px" }}>
+        <div style={{ height: "80px" }}>
+          {this.state.message}
+        </div>
+        <div style={{ textAlign: "right" }}>
+          {this.state.buttons.map(item => {
+            counter++;
+            return (
+            <Button key={item} variant={counter === 1 ? "primary" : "secondary"} style={{ marginLeft: "10px" }}
+              onClick={() => this.onButtonClick(item)}>
+              {item}
+            </Button>)
+          })}
+        </div>
+      </div>
+    )
+  }
+}

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -33,6 +33,12 @@ export interface SetupParams {
   consentTelemetry: boolean;
   pullsecret: string;
 }
+export interface DialogOptions {
+  message: string;
+  title: string;
+  buttons: string[];
+}
+
 export declare global {
   interface Window {
     api: {
@@ -76,6 +82,11 @@ export declare global {
        */
       closeSetupWizard: () => void;
 
+      showModalDialog: (title: string, message: string, ...items: string[]) => Promise<string>;
+    },
+    dialogApi: {
+      getDialogOptions: () => Promise<DialogOptions>;
+      buttonClicked: (value: string) => void;
     }
   }
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -11,6 +11,7 @@ import ConfigurationWindow from './components/ConfigurationWindow';
 import MiniStatusWindow from './components/MiniStatusWindow';
 import PullSecretChangeWindow from './components/PullSecretChangeWindow';
 import { AboutWindow } from './components/about/AboutWindow';
+import { DialogWindow } from './components/dialog/DialogWindow';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -24,6 +25,7 @@ ReactDOM.render(
         <Route path="/ministatus" element={<MiniStatusWindow />} />
         <Route path="/pullsecret" element={<PullSecretChangeWindow />} />
         <Route path="/about" element={<AboutWindow />} />
+        <Route path="/dialog" element={<DialogWindow />} />
       </Routes>
     </HashRouter>
   </React.StrictMode>,

--- a/main.js
+++ b/main.js
@@ -19,6 +19,8 @@ const Telemetry = require('./telemetry');
 const showNotification = require('./notification');
 const which = require('which');
 
+const { showModalDialog } = require('./build/dialog');
+
 const config = new Config()
 // create the telemetry object
 const telemetry = new Telemetry(config.get('enableTelemetry'), getSegmentWriteKey())
@@ -910,4 +912,13 @@ ipcMain.handle('get-about', async () => {
     ocpBundleVersion: version.OpenshiftVersion,
     podmanVersion: version.PodmanVersion
   };
+});
+
+/* ----------------------------------------------------------------------------
+// Dialog
+// ------------------------------------------------------------------------- */
+
+ipcMain.handle('open-dialog', async (event, title, message, ...items) => {
+  const window = BrowserWindow.fromWebContents(event.sender);
+  return showModalDialog(window, {title, message, type: "question"}, ...items);
 });

--- a/package.json
+++ b/package.json
@@ -7,15 +7,18 @@
   "main": "main.js",
   "scripts": {
     "build:react": "cd frontend && npm run build",
-    "start": "npm run build:react && electron .",
-    "release": "npm run build:react && electron-packager . --ignore='frontend/package.json' --ignore='/frontend/node_modules' --ignore='/frontend/src' --overwrite --asar --out=release --prune=true --icon=assets/appicon",
-    "release:cross": "npm run build:react && electron-packager . --ignore='/frontend/package.json' --ignore='/frontend/node_modules' --ignore='/frontend/src' --overwrite --asar --out=release --platform=darwin,win32 --prune=true --icon=assets/appicon --app-bundle-id='com.redhat.codeready.containers'",
-    "start:dev": "concurrently \"electron .\" \"cd frontend && npm start\""
+    "build": "tsc -p .",
+    "watch": "tsc -w -p .",
+    "start": "npm run build && npm run build:react && electron .",
+    "release": "npm run build && npm run build:react && electron-packager . --ignore='frontend/package.json' --ignore='/frontend/node_modules' --ignore='/frontend/src' --overwrite --asar --out=release --prune=true --icon=assets/appicon",
+    "release:cross": "npm run build && npm run build:react && electron-packager . --ignore='/frontend/package.json' --ignore='/frontend/node_modules' --ignore='/frontend/src' --overwrite --asar --out=release --platform=darwin,win32 --prune=true --icon=assets/appicon --app-bundle-id='com.redhat.codeready.containers'",
+    "start:dev": "concurrently \"npm run watch\" \"electron .\" \"cd frontend && npm start\""
   },
   "devDependencies": {
     "concurrently": "^6.4.0",
     "electron": "^16.0.4",
-    "electron-packager": "^15.4.0"
+    "electron-packager": "^15.4.0",
+    "typescript": "^4.5.5"
   },
   "dependencies": {
     "analytics-node": "^6.0.0",

--- a/preload-main.js
+++ b/preload-main.js
@@ -73,5 +73,10 @@ contextBridge.exposeInMainWorld('api', {
 
   about: () => {
     return ipcRenderer.invoke('get-about');
-  }
+  },
+
+  showModalDialog: (title, message, ...items) => {
+    return ipcRenderer.invoke('open-dialog', title, message, ...items);
+  },
+
 });

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -1,0 +1,79 @@
+import { BrowserWindow, app, ipcMain} from 'electron';
+import * as path from 'path';
+
+export type DialogType =  "none" | "info" |  "error" | "question" | "warning"
+export interface DialogOptions {
+  message: string;
+  title: string;
+  type: DialogType;
+}
+let dialogWindow: BrowserWindow | undefined;
+
+// TODO: extract this in separate module
+function getFrontEndUrl(route: string) {
+  let frontEndUrl = 'http://localhost:3000'
+  if (app.isPackaged) {
+    frontEndUrl = `file://${path.join(app.getAppPath(), 'frontend', 'build', 'index.html')}`
+  }
+  return (!route || route === "") ? frontEndUrl : `${frontEndUrl}#/${route}`;
+}
+
+/**
+ * Show Dialog Window. 
+ * If parentWindow is provided, dialog will be modal
+ * @param parentWindow if set dialog will be modal, optional
+ * @param options the dialog options
+ * @param items the items, which will be a Buttons in dialog
+ * @returns promise which resolve one of 'items' or undefined
+ */
+export async function showDialog(parentWindow: BrowserWindow | undefined, options: DialogOptions, ...items: string[]): Promise<string | undefined> {
+  if(dialogWindow) {
+    return Promise.reject('Only one dialog could be displayed at same time!');
+  }
+  return new Promise(async (resolve, reject) => {
+    let itemSelected = false;
+    ipcMain.handleOnce('dialog-options', () => {
+      return {...options, buttons: items};
+    });
+
+    ipcMain.once('dialog-button', (_, value: string) => {
+      if(dialogWindow) {
+        itemSelected = true;
+        dialogWindow.close();
+        dialogWindow = undefined;
+      }
+      if(items.includes(value)) {
+        resolve(value);
+      } else {
+        reject(`Dialog return unknown item: '${value}'!`);
+      }
+    });
+
+    dialogWindow = new BrowserWindow({
+      width: 800,
+      height: 200,
+      modal: parentWindow !== undefined,
+      parent: parentWindow,
+      resizable: false,
+      maximizable: false,
+      minimizable: false,
+      show: false,
+      webPreferences: {
+        preload: path.join(__dirname, "preload-dialog.js")
+      }
+      //icon TODO: add icon
+    });
+    dialogWindow.on('close',  e => {
+      if(!itemSelected) {
+        dialogWindow = undefined;
+        resolve(undefined);
+      }
+    });
+
+    dialogWindow.setMenuBarVisibility(false)
+    await dialogWindow.loadURL(getFrontEndUrl('dialog'));
+
+    dialogWindow.show();
+  });
+  
+}

--- a/src/preload-dialog.ts
+++ b/src/preload-dialog.ts
@@ -1,0 +1,10 @@
+import {contextBridge, ipcRenderer} from 'electron';
+
+contextBridge.exposeInMainWorld("dialogApi", {
+  getDialogOptions: (): Promise<{}> => {
+    return ipcRenderer.invoke('dialog-options');
+  },
+  buttonClicked: (value: string): void => {
+    ipcRenderer.send('dialog-button', value);
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,102 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    "outDir": "build",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src"],
+}


### PR DESCRIPTION
This Dialog API is pretty straightforward:

On main thread import `showDialog` function from `src/dialog.ts`,
example of usage:
```typescript
const result = await showDialog(parentWindowOrUndefined, {title: "Foo", message: "Bar?'}, "Yes", "No");
```

On any renderer thread, which loaded with `preload-main.js`, `showModalDialog` function exposed in `window.api` object.
Example:

```typescript
const result = await document.api.showModalDialog('Title', 'Message', 'Yes', 'No', 'Cancel');
```

A small demo:

https://user-images.githubusercontent.com/929743/153597806-ae4e2d72-a3b0-4c61-87de-77ec4bff7fbd.mov


