### PR TITLE
Fixes #142 Add confirmation dialog on delete action

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
           "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
         },
         "args" : [".", "--inspect=5858", "--remote-debugging-port=8315"],
-        "outputCapture": "std"
+        "outputCapture": "std",
+        "preLaunchTask": "watch typescript",
       }
     ]
   }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "watch typescript",
+      "type": "shell",
+      "command": "npm run watch",
+      "presentation": {
+        "reveal": "never"
+      },
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+  ]
+}

--- a/frontend/src/components/MiniStatusWindow.tsx
+++ b/frontend/src/components/MiniStatusWindow.tsx
@@ -49,8 +49,11 @@ export default class MiniStatusWindow extends React.Component {
     }
   }
 
-  onDelete() {
-    window.api.deleteInstance({})
+  async onDelete(): Promise<void> {
+    const result = await window.api.showModalDialog('Warning','Are you sure you want to delete the CodeReady Containers instance? This is a destructive operation and can not be undone.', 'Yes', 'No');
+    if(result === 'Yes') {
+      window.api.deleteInstance({})
+    }
   }
 
   render() {

--- a/frontend/src/components/dialog/DialogWindow.tsx
+++ b/frontend/src/components/dialog/DialogWindow.tsx
@@ -28,7 +28,7 @@ export class DialogWindow extends React.Component {
   render(): React.ReactNode {
     let counter = 0;
     return (
-      <div style={{ margin: "20px" }}>
+      <div style={{ paddingTop: "30px", paddingLeft: "30px", paddingRight: "30px" }}>
         <div style={{ height: "80px" }}>
           {this.state.message}
         </div>

--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const Telemetry = require('./telemetry');
 const showNotification = require('./notification');
 const which = require('which');
 
-const { showModalDialog } = require('./build/dialog');
+const { showDialog } = require('./build/dialog');
 
 const config = new Config()
 // create the telemetry object
@@ -920,5 +920,5 @@ ipcMain.handle('get-about', async () => {
 
 ipcMain.handle('open-dialog', async (event, title, message, ...items) => {
   const window = BrowserWindow.fromWebContents(event.sender);
-  return showModalDialog(window, {title, message, type: "question"}, ...items);
+  return showDialog(window, {title, message, type: "question"}, ...items);
 });


### PR DESCRIPTION
This PR also adds `tasks.json` for vscode, to auto start `npm run watch` command for running `tsc` in watch mode, during launching tray app from vscode.

Demo on mac os:
<img width="912" alt="Screenshot 2022-02-15 at 11 48 35" src="https://user-images.githubusercontent.com/929743/154039455-c0a3df8f-3f72-4efe-a4aa-28f6d527f2e9.png">

