### PR TITLE
set tray to autostart during onboarding

### DIFF
--- a/frontend/src/components/Configuration.tsx
+++ b/frontend/src/components/Configuration.tsx
@@ -25,6 +25,8 @@ export interface ConfigurationProps {
     onResetClicked: () => void;
     onPresetChange: (preset: string) => void;
     onCancelClicked: () => void;
+    isAutostartEnabled: () => Promise<boolean>;
+    saveAutostartConfig: (checked: boolean) => void;
 }
 
 export interface State {
@@ -46,7 +48,9 @@ export class Configuration extends React.Component<ConfigurationProps> {
         onPullsecretChangeClicked: PropTypes.func,
         onPresetChange: PropTypes.func,
         height: PropTypes.string,
-        textInputWidth: PropTypes.string
+        textInputWidth: PropTypes.string,
+        isAutostartEnabled: PropTypes.func,
+        saveAutostartConfig: PropTypes.func
     };
 
     static defaultProps = {
@@ -82,6 +86,12 @@ export class Configuration extends React.Component<ConfigurationProps> {
             "proxy-ca-file": ""
         };
 
+        props.isAutostartEnabled().then(enabled => {
+            this.setState({
+                autostartTrayEnabled: enabled ? 1 :0 
+            })
+        })
+
         this.configurationSaveClicked = this.configurationSaveClicked.bind(this);
         this.configurationResetClicked = this.configurationResetClicked.bind(this);
         this.handleTabClick = this.handleTabClick.bind(this);
@@ -90,6 +100,7 @@ export class Configuration extends React.Component<ConfigurationProps> {
         this.getMimimum = this.getMimimum.bind(this);
         this.updateValue = this.updateValue.bind(this);
         this.presetChanged = this.presetChanged.bind(this)
+        this.handleTrayAutostart = this.handleTrayAutostart.bind(this);
     }
 
     // Toggle currently active tab
@@ -144,15 +155,30 @@ export class Configuration extends React.Component<ConfigurationProps> {
 
     configurationSaveClicked() {
         this.props.onSaveClicked(this.state);
+
+        // save autostart tray config
+        this.props.saveAutostartConfig(this.state.autostartTrayEnabled === 1 ? true : false)
     }
 
     configurationResetClicked() {
         this.props.onResetClicked();
+
+        // refresh autostartTrayEnabled state
+        this.props.isAutostartEnabled().then(enabled => {
+            this.setState({
+                autostartTrayEnabled: enabled ? 1 : 0
+            })
+        })
+    }
+
+    handleTrayAutostart(value: boolean) {
+        this.setState({
+            autostartTrayEnabled: value ? 1 : 0
+        })
     }
 
     render() {
         const {activeTabKey } = this.state;
-
         const tabStyle = {
             height: this.props.height,
         }
@@ -233,6 +259,15 @@ export class Configuration extends React.Component<ConfigurationProps> {
                                         onChange={value => this.updateValue('consent-telemetry', value === true ? "yes" : "no")}
                                         label="Allow telemetry data to be sent to Red Hat"
                                         description="Allow basic information about the system and cluster to be collected for development and debugging purposes" />
+                                </FormGroup>
+                                <FormGroup fieldId='config-tray-autostart' label="Autostart">
+                                    <Checkbox id='config-trayAutostart'
+                                        className="trayAutostart"
+                                        isChecked={ this.state.autostartTrayEnabled === 1 ? true : false }
+                                        onChange={ this.handleTrayAutostart }
+                                        label="Autostart tray at login"
+                                        description="Automatically start the tray application after the user logs in"
+                                        />
                                 </FormGroup>
                             </Form>
                         </TabContentBody>

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -84,7 +84,7 @@ export declare global {
       showModalDialog: (title: string, message: string, ...items: string[]) => Promise<string>;
 
       autoStart: {
-        isEnabled: () => boolean;
+        isEnabled: () => Promise<boolean>;
         enable: () => void;
         disable: () => void;
       }

--- a/frontend/src/global.d.ts
+++ b/frontend/src/global.d.ts
@@ -82,6 +82,12 @@ export declare global {
       closeSetupWizard: () => void;
 
       showModalDialog: (title: string, message: string, ...items: string[]) => Promise<string>;
+
+      autoStart: {
+        isEnabled: () => boolean;
+        enable: () => void;
+        disable: () => void;
+      }
     },
     dialogApi: {
       getDialogOptions: () => Promise<DialogOptions>;

--- a/frontend/src/windows/ConfigurationWindow.tsx
+++ b/frontend/src/windows/ConfigurationWindow.tsx
@@ -24,6 +24,8 @@ export default class ConfigurationWindow extends React.Component {
         this.openPullsecretChangeWindow = this.openPullsecretChangeWindow.bind(this);
         this.onCancelClicked = this.onCancelClicked.bind(this);
         this.onPresetChangeClicked = this.onPresetChangeClicked.bind(this);
+        this.saveAutostartConfig = this.saveAutostartConfig.bind(this);
+        this.isAutostartEnabled = this.isAutostartEnabled.bind(this);
 
         this.config = React.createRef();
     }
@@ -78,6 +80,18 @@ export default class ConfigurationWindow extends React.Component {
     openPullsecretChangeWindow() {
         window.api.openPullsecretChangeWindow({})
     }
+    
+    async isAutostartEnabled(): Promise<boolean> {
+        return window.api.autoStart.isEnabled()
+    }
+
+    saveAutostartConfig(checked: boolean) {
+        if (checked) {
+            window.api.autoStart.enable()
+        } else {
+            window.api.autoStart.disable()
+        }
+    }
 
     private onCancelClicked(): void {
         window.close();
@@ -91,6 +105,8 @@ export default class ConfigurationWindow extends React.Component {
                 onPullsecretChangeClicked={this.openPullsecretChangeWindow}
                 onCancelClicked={this.onCancelClicked}
                 onPresetChange={this.onPresetChangeClicked}
+                isAutostartEnabled={this.isAutostartEnabled}
+                saveAutostartConfig={this.saveAutostartConfig}
                 height="320px" />
         );
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1128,18 +1128,18 @@ ipcMain.handle('open-setup-window', (event) => {
 // Autostart
 // ------------------------------------------------------------------------- */
 
-ipcMain.on('enable-autostart', async () => {
-  app.setLoginItemSettings({
+ipcMain.on('enable-autostart', () => {
+  return app.setLoginItemSettings({
     openAtLogin: true
   })
 })
 
-ipcMain.on('disable-autostart', async () => {
-  app.setLoginItemSettings({
+ipcMain.on('disable-autostart', () => {
+  return app.setLoginItemSettings({
     openAtLogin: false
   })
 })
 
-ipcMain.handle('is-autostart-enabled', async () => {
+ipcMain.handle('is-autostart-enabled', () => {
   return app.getLoginItemSettings().openAtLogin
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,6 +178,9 @@ if (!gotTheLock) {
 
   app.whenReady().then(async () => {
     if (needOnboarding()) {
+      app.setLoginItemSettings({
+        openAtLogin: true
+      })
       showOnboarding()
     } else {
       daemonStart();
@@ -1121,3 +1124,22 @@ ipcMain.handle('open-setup-window', (event) => {
   });
 });
 
+/*----------------------------------------------------------------------------
+// Autostart
+// ------------------------------------------------------------------------- */
+
+ipcMain.on('enable-autostart', async () => {
+  app.setLoginItemSettings({
+    openAtLogin: true
+  })
+})
+
+ipcMain.on('disable-autostart', async () => {
+  app.setLoginItemSettings({
+    openAtLogin: false
+  })
+})
+
+ipcMain.handle('is-autostart-enabled', async () => {
+  return app.getLoginItemSettings().openAtLogin
+})

--- a/src/preload-main.ts
+++ b/src/preload-main.ts
@@ -86,16 +86,16 @@ contextBridge.exposeInMainWorld('api', {
   },
   
   autoStart: {
-    isEnabled: async () =>  {
-      return await ipcRenderer.invoke('is-autostart-enabled');
+    isEnabled: () =>  {
+      return ipcRenderer.invoke('is-autostart-enabled');
     },
 
     enable: () => {
-      ipcRenderer.send('enable-autostart');
+      return ipcRenderer.send('enable-autostart');
     },
 
     disable: () => {
-      ipcRenderer.send('disable-autostart');
+      return ipcRenderer.send('disable-autostart');
     }
   }
 

--- a/src/preload-main.ts
+++ b/src/preload-main.ts
@@ -84,5 +84,19 @@ contextBridge.exposeInMainWorld('api', {
   openSetupWindow: () => {
     return ipcRenderer.invoke('open-setup-window');
   },
+  
+  autoStart: {
+    isEnabled: async () =>  {
+      return await ipcRenderer.invoke('is-autostart-enabled');
+    },
+
+    enable: () => {
+      ipcRenderer.send('enable-autostart');
+    },
+
+    disable: () => {
+      ipcRenderer.send('disable-autostart');
+    }
+  }
 
 });


### PR DESCRIPTION
this assumes when we need to launch the on-boarding, that means the user has reinstalled, in which case his older setting for auto-start will be overwritten

we need to modify the config window autostart-tray option to use the following functions instead of requesting the daemon:
 `window.api.autoStart.enable()`
`window.api.autoStart.disable()`
`window.api.autoStart.isEnabled()`

related to https://github.com/code-ready/crc/pull/3009