### PR TITLE
rename the file storing segment hash to segmentIdentifyHashForTray

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
+    "@types/segment-analytics": "^0.0.34",
     "analytics-node": "^6.0.0",
     "electron-is-dev": "^2.0.0",
     "electron-store": "^8.0.1",

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -6,7 +6,7 @@ const fs = require('fs');
 const {v4: uuidv4 } = require('uuid');
 const hash = require('object-hash');
 
-let userIdHashPath = path.join(os.homedir(), '.crc', "segmentIdentityHash");
+let userIdHashPath = path.join(os.homedir(), '.crc', "segmentIdentifyHashForTray");
 let userIdPath = path.join(os.homedir(), '.redhat', 'anonymousId');
 
 interface Properties {


### PR DESCRIPTION
- install the npm package @types/segment-analytics