### PR TITLE
Fix NumberInput styles

### DIFF
--- a/frontend/src/components/Configuration.tsx
+++ b/frontend/src/components/Configuration.tsx
@@ -13,6 +13,8 @@ import "./Configuration.scss";
 
 import { PresetSelection } from './PresetSelection';
 
+import '@patternfly/react-styles/css/components/InputGroup/input-group.css';
+
 export interface ConfigurationProps {
     readonly height: string;
     readonly textInputWidth: number;


### PR DESCRIPTION
Now it should look normally:
<img width="781" alt="Screenshot 2022-02-22 at 10 16 55" src="https://user-images.githubusercontent.com/929743/155090651-141dd8c4-125f-41c8-8861-9a709d6dc2f4.png">

But I think we need to review the way how we include patternfly styles.
