### PR TITLE
bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crc-tray",
   "license": "Apache-2.0",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "author": "",
   "main": "build/src/main.js",


### PR DESCRIPTION
this version number is greater than the old native tray on macos
which will make sure that the tray app is replaced when using the
pkg installer