### PR TITLE
Increase startup delay of the tray

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,8 @@ if (!gotTheLock) {
       showOnboarding()
     } else {
       daemonStart();
-      delay(4000);
+      // TODO: Startup delay, only show when daemon active
+      delay(8000);
       appStart();
     }
   });


### PR DESCRIPTION
At the moment we do not check the state of the daemon.
When the daemon is not available, the pull secret need call triggers unnecessary on start