### PR TITLE
Issue #164 enclose crc executable path in quotes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -471,7 +471,7 @@ const prepareDevTerminalForPreset = async function(preset: DevTerminalType) {
     }
   } else if (isMac) {
     var script = `tell application "Terminal"
-    do script "eval $(${crcBinary()} ${command})"
+    do script "eval $('${crcBinary()}' ${command})"
 end tell
 
 tell application "System events"


### PR DESCRIPTION
this is to prevent the following error which occurs
due to a white-space in the crc executable path

```
zsh: no such file or directory: /Applications/CodeReady
```

/cc @praveenkumar can you please test and see if this is working for you now, use the artifact from the CI and put `crc` binary inside path `crc-tray.app/Contents/Resources`