### PR TITLE
Sow confirmation dialog for delete action

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -565,8 +565,17 @@ const onToggleInstanceState = function(state: string) {
   }
 }
 
-const onInstanceDelete = function() {
-  deleteInstance();
+const onInstanceDelete = async function() {
+  const result = await dialog.showMessageBox({
+    title: 'Delete', 
+    message: 'Are you sure you want to delete the CodeReady Containers instance? This is a destructive operation and can not be undone.',
+    type: 'warning',
+    buttons: ["Yes", "No"],
+    cancelId: 1
+  });
+  if(result.response === 0) {
+    deleteInstance();
+  }
 }
 
 const createTrayMenu = function(status: State) {


### PR DESCRIPTION
This is implemented with native dialog:
<img width="291" alt="Screenshot 2022-02-28 at 16 39 09" src="https://user-images.githubusercontent.com/929743/156002034-aae85511-61ca-4ac1-bdda-96675624dc00.png">

But I easily change with our dialog window
