### PR TITLE
surround crc command in quotes ran in developer terminal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -453,7 +453,7 @@ const prepareDevTerminalForPreset = async function(preset: DevTerminalType) {
   if (isWin) {
     var poshPath = which.sync("powershell.exe", { nothrow: true })
     if (poshPath !== null) {
-      const posh = childProcess.spawn(poshPath, [`-NoExit -command "& {${crcBinary()} ${command} | Invoke-Expression}"`], {
+      const posh = childProcess.spawn(poshPath, [`-NoExit -command "&'${crcBinary()} ${command} | Invoke-Expression'"`], {
         detached: true,
         shell: true,
         cwd: os.homedir(),


### PR DESCRIPTION
this fixes the error that prevents opening developer terminal
in windows because of the white space in the path to crc executable

![image(1)](https://user-images.githubusercontent.com/8885742/156398544-06793223-42cf-409e-a6f8-e0404ab47d67.png)
