### PR TITLE
Issue #192 move pollStatus call to inside appStart

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -183,7 +183,6 @@ if (!gotTheLock) {
       daemonStart();
       // TODO: Startup delay, only show when daemon active
       await delay(8000);
-      pollStatus();
       appStart();
     }
   });
@@ -360,6 +359,9 @@ const appStart = async function() {
   tray.on('right-click', (e, bounds) => {
     tray?.popUpContextMenu(trayMenu);
   });
+
+  // start polling for status
+  pollStatus()
 }
 
 const pollStatus = async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -826,6 +826,9 @@ const startInstance = async function() {
   }
   catch(e) {
     console.log("Action error: " + e)
+    showNotification({
+      body: "There was an error in starting CodeReady Containers instance: " + e
+    })
   }
 }
 
@@ -844,6 +847,9 @@ const stopInstance = function() {
   }
   catch(e) {
     console.log("Action error: " + e)
+    showNotification({
+      body: "There was an error in stopping CodeReady Containers instance: " + e
+    })
   }
 }
 
@@ -862,6 +868,9 @@ const deleteInstance = function() {
   }
   catch(e) {
     console.log("Action error: " + e)
+    showNotification({
+      body: "There was an error in deleting CodeReady Containers instance: " + e
+    })
   }
 }
 


### PR DESCRIPTION
`appStart` is used to start the tray from the on-boarding