### PR TITLE
Always start the daemon when tray is started

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -179,7 +179,7 @@ if (!gotTheLock) {
   app.whenReady().then(async () => {
     daemonStart();
     // TODO: Startup delay, only show when daemon active
-    await delay(8000);
+    await delay(2000);
     if (needOnboarding()) {
       app.setLoginItemSettings({
         openAtLogin: true

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,15 +177,15 @@ if (!gotTheLock) {
   })
 
   app.whenReady().then(async () => {
+    daemonStart();
+    // TODO: Startup delay, only show when daemon active
+    await delay(8000);
     if (needOnboarding()) {
       app.setLoginItemSettings({
         openAtLogin: true
       })
       showOnboarding()
     } else {
-      daemonStart();
-      // TODO: Startup delay, only show when daemon active
-      await delay(8000);
       appStart();
     }
   });


### PR DESCRIPTION
this is needed as otherwise the on-boarding will always be
shown as `crc setup --check-only` now expects daemon to be
running

Needed for https://github.com/code-ready/crc/pull/3088