### PR TITLE
dont try to change preset in case running on M1

### DIFF
--- a/src/preload-setup.ts
+++ b/src/preload-setup.ts
@@ -28,7 +28,7 @@ contextBridge.exposeInMainWorld('api', {
 
   forceEndErrorDuringSetup: () => {
     ipcRenderer.send('force-end-setup-error');
-},
+  },
 
   removeSetupLogListeners: () => {
     ipcRenderer.removeAllListeners('setup-logs-async')


### PR DESCRIPTION
This prevents the following error, when using M1 bits of crc with the tray:

```
[...]

level=info msg="Checking if crc daemon plist file is present and loaded"
File not found: /Users/anjan/Library/LaunchAgents/com.redhat.crc.daemon.plist: stat /Users/anjan/Library/LaunchAgents/com.redhat.crc.daemon.plist: no such file or directory

Configuration property 'preset' does not exist
```