### PR TITLE
bump version to 1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crc-tray",
   "license": "Apache-2.0",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "",
   "author": "Red Hat, Inc.",
   "main": "build/src/main.js",


### PR DESCRIPTION
1.2.8 release tag was created but version  bump
in package.json was missed, so the next version
is 1.2.9