### PR TITLE
npm: downgrade got npm module to 11.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "analytics-node": "^6.2.0",
     "electron-is-dev": "^2.0.0",
     "electron-store": "^8.1.0",
-    "got": "^12.5.2",
+    "got": "11.8.3",
     "object-hash": "^3.0.0",
     "uuid": "^9.0.0",
     "which": "^2.0.2"


### PR DESCRIPTION
the latest versions of the module is a native ESM
module and doesn't work with electron which is still commonJS

the authors of the module suggest to use v11 of the module if using in a commonJS project

ref: https://github.com/sindresorhus/got/tree/main#install


fixes #228 